### PR TITLE
Fixed #5, starting position glitch

### DIFF
--- a/core/src/io/jcurtis/jcore/gameobject/components/BoxCollider.kt
+++ b/core/src/io/jcurtis/jcore/gameobject/components/BoxCollider.kt
@@ -28,14 +28,12 @@ class BoxCollider: Component() {
     private var collisions = mutableListOf<BoxCollider>()
     private var newCollisions = mutableListOf<BoxCollider>()
 
-    init {
-        Core.colliders.add(this)
+    override fun init() {
+        rectangle.setPosition(transform.position)
         rectangle.width = width
         rectangle.height = height
-    }
 
-    override fun init() {
-        return
+        Core.colliders.add(this)
     }
 
     fun getTop(): Float {

--- a/core/src/io/jcurtis/jcore/gameobject/components/RigidBody.kt
+++ b/core/src/io/jcurtis/jcore/gameobject/components/RigidBody.kt
@@ -24,6 +24,7 @@ class RigidBody: Component() {
         var collidesXY = checkCollisionsAt(transform.position.cpy().add(velocity.x, velocity.y))
 
         if (collidesX.isNotEmpty()) {
+            println("player colliding")
             val box = collidesX[0]
             if (velocity.x > 0)
                 transform.position.x = box.getLeft() - collider.width
@@ -33,6 +34,7 @@ class RigidBody: Component() {
         }
 
         if (collidesY.isNotEmpty()) {
+            println("player colliding")
             val box = collidesY[0]
             if (velocity.y > 0)
                 // up
@@ -44,6 +46,7 @@ class RigidBody: Component() {
         }
 
         if (collidesXY.isNotEmpty() && collidesX.isEmpty() && collidesY.isEmpty()) {
+            println("player colliding")
             val box = collidesXY[0]
             if (velocity.x > 0)
                 transform.position.x = box.getLeft() - collider.width
@@ -66,6 +69,6 @@ class RigidBody: Component() {
         collider.rectangle.x = position.x
         collider.rectangle.y = position.y
 
-        return Core.colliders.filter { c -> (c.rectangle.overlaps(collider.rectangle) && c != collider) }
+        return Core.colliders.filter { it.rectangle != collider.rectangle && it.rectangle.overlaps(collider.rectangle) }
     }
 }

--- a/core/src/io/jcurtis/jcore/test/Main.kt
+++ b/core/src/io/jcurtis/jcore/test/Main.kt
@@ -32,6 +32,5 @@ class Main: JCoreGame() {
         }
         player.attach<RigidBody>()
 
-        player.transform!!.position.setZero()
     }
 }

--- a/core/src/io/jcurtis/jcore/test/PlayerController.kt
+++ b/core/src/io/jcurtis/jcore/test/PlayerController.kt
@@ -2,10 +2,10 @@ package io.jcurtis.jcore.test
 
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.Input.Keys
+import io.jcurtis.jcore.gameobject.components.BoxCollider
 import io.jcurtis.jcore.gameobject.components.Component
 import io.jcurtis.jcore.gameobject.components.RigidBody
 
-@Suppress("SpellCheckingInspection")
 class PlayerController : Component() {
     private var speed = 100
     private var rigidbody: RigidBody? = null


### PR DESCRIPTION
Previously, having a `RigidBody` start at `X: 0, Y: 0` when a `TilemapCollider` is present caused issues. The reason for this was because `BoxCollider` got added to `Core.colliders` *before* it's position got set.